### PR TITLE
#SU4NA-50: Обновление тайтлов пачкой не работает

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -57,17 +57,27 @@ func (sj *ShikimoriJob) Run() {
 		time.Sleep(1000 * time.Millisecond)
 	}
 	//then we need to run long loading of animes by call url '/api/animes/:id'
-	var animesDtos, err = sj.GetNotProcessedExternalAnimes()
+	//TODO write test for this bug!!!
+	animesDtos, err := sj.GetNotProcessedExternalAnimes()
 	if err != nil {
 		util.HandleError(err)
 		return
 	}
-	for _, animeDto := range animesDtos {
-		processOneAmineErr := sj.ProcessOneAnime(animeDto)
-		if processOneAmineErr != nil {
-			util.HandleError(processOneAmineErr)
+	for len(animesDtos) > 0 {
+		for _, animeDto := range animesDtos {
+			processOneAmineErr := sj.ProcessOneAnime(animeDto)
+			if processOneAmineErr != nil {
+				util.HandleError(processOneAmineErr)
+				return
+			}
+			time.Sleep(1000 * time.Millisecond)
 		}
-		time.Sleep(1000 * time.Millisecond)
+		animeDtosBatch, err := sj.GetNotProcessedExternalAnimes()
+		if err != nil {
+			util.HandleError(err)
+			return
+		}
+		animesDtos = animeDtosBatch
 	}
 }
 

--- a/models/animes.go
+++ b/models/animes.go
@@ -546,14 +546,14 @@ type AnimeQueryBuilder struct {
 	Ids        []string
 	ExcludeIds []string
 	SQLQuery   strings.Builder
-	Processed  bool
+	Processed  *bool
 	CountOnly  bool
 	RowNumber  int64
 }
 
 //SetProcessed function
 func (aqb *AnimeQueryBuilder) SetProcessed(processed bool) {
-	aqb.Processed = processed
+	aqb.Processed = &processed
 }
 
 //AddExcludeID function
@@ -840,7 +840,7 @@ func (aqb *AnimeQueryBuilder) Build() (string, []interface{}) {
 		aqb.SQLQuery.WriteString(strconv.Itoa(countOfParameter))
 		args = append(args, aqb.Score)
 	}
-	if aqb.Processed == true {
+	if aqb.Processed != nil {
 		countOfParameter++
 		aqb.SQLQuery.WriteString(" AND animes.processed = $")
 		aqb.SQLQuery.WriteString(strconv.Itoa(countOfParameter))


### PR DESCRIPTION
Исправил таким образом, чтобы партиями считывать аниме до тех пор, пока необрабтанные не закончатся. На самом деле способ, к которому прибег не очень хорош, поскольку читает необработанные данные, которые если не будут прибывать в большем объеме, чем можно обработать, то будут возможно неправильно обрабатываться приложением, нефиксируя транзакции на базе и не увеличивая количество обработанных данных в базе, в результате чего могут возникнуть ситуации, когда цикл будет считывать необработанные данные из базы вечно.